### PR TITLE
UI: differentiate between running and failed test.

### DIFF
--- a/common.php
+++ b/common.php
@@ -49,7 +49,8 @@ function color_label_text_grade($score) {
 		case 'T':
 			return "label-warning";
 		case NULL:
-			return "label-default";
+        case '?':
+            return "label-default";
 		default:
 			return "label-danger";
 	}
@@ -300,4 +301,32 @@ function common_header($head) {
 
 <?php
 
+}
+
+function show_score_label($result, $scores) {
+    $final_score = NULL;
+    $all_error = $scores; // 'false' if no scores are provided.
+    $all_done = true;
+    if ($scores) {
+        foreach ($scores as $score) {
+            if (grade($score) && (!$final_score || grade($score) < $final_score)) {
+                $final_score = grade($score);
+            }
+            if ($score["done"] !== "t") {
+                $all_done = false;
+            }
+            if ($score["error"] === NULL) {
+                $all_error = false;
+            }
+        }
+    }
+
+    if (!$all_done) {
+        $label = "<div class=\"lds-facebook\"><div></div><div></div><div></div></div>";
+    } else if ($all_error || $result["error"] !== NULL) {
+        $label = "E";
+    } else {
+        $label = $final_score !== NULL ? $final_score : "?";
+    }
+?><span class="<?= $all_done ? color_label_text_grade($label) : "" ?> label"><?= $label ?></span><?= $final_score !== NULL && count($scores) > 1 ? "*" : "" ?><?php
 }

--- a/css/main.css
+++ b/css/main.css
@@ -64,3 +64,41 @@ h2[id], h3[id] {
 	width: 100%;
 	height: 450px;
 }
+
+/* source: loading.io */
+.lds-facebook {
+	display: inline-block;
+	position: relative;
+	width: 2em;
+	height: 1em;
+}
+.lds-facebook div {
+	display: inline-block;
+	position: absolute;
+	left: -0.6em;
+	width: .5em;
+	background: #999;
+	animation: lds-facebook 1.2s cubic-bezier(0, 0.5, 0.5, 1) infinite;
+}
+.lds-facebook div:nth-child(1) {
+	left: -0.6em;
+	animation-delay: -0.24s;
+}
+.lds-facebook div:nth-child(2) {
+	left: 0.15em;
+	animation-delay: -0.12s;
+}
+.lds-facebook div:nth-child(3) {
+	left: 0.9em;
+	animation-delay: 0s;
+}
+@keyframes lds-facebook {
+	0% {
+		top: 0;
+		height: 1em;
+	}
+	50%, 100% {
+		top: 0.25em;
+		height: 0.5em;
+	}
+}

--- a/index.php
+++ b/index.php
@@ -84,18 +84,7 @@ if ($list) {
 	?>
 							<tr>
 								<td><a href="result.php?domain=<?= $result["server_name"] ?>&amp;type=<?= $result["type"] ?>"><?= $result["server_name"] ?></a> <span class="text-muted"><?= $result["type"] ?></span></td>
-	<?php
-		$final_score = NULL;
-
-		if ($scores) {
-			foreach ($scores as $score) {
-				if (grade($score) && (!$final_score || grade($score) < $final_score)) {
-					$final_score = grade($score);
-				}
-			}
-		}
-	?>
-								<td><span class="<?= color_label_text_grade($final_score) ?> label"><?= $final_score === NULL ? "?" : $final_score ?></span><?= $final_score !== NULL && count($scores) > 1 ? "*" : "" ?></td>
+								<td><? show_score_label($result, $scores); ?></td>
 							</tr>
 	<?php
 	}

--- a/list.php
+++ b/list.php
@@ -70,17 +70,7 @@ foreach ($list as $result) {
 			<tr>
 				<td><a href="result.php?domain=<?= $result["server_name"] ?>&amp;type=<?= $result["type"] ?>"><?= $result["server_name"] ?></a></td>
 				<td><?= $result["type"] ?> to server</td>
-<?php
-	$final_score = NULL;
-    if ($scores) {
-	    foreach ($scores as $score) {
-		    if (grade($score) && (!$final_score || grade($score) < $final_score)) {
-			    $final_score = grade($score);
-		    }
-	    }
-    }
-?>
-				<td><span class="<?= color_label_text_grade($final_score) ?> label"><?= $final_score === NULL ? "?" : $final_score ?></span><?= $final_score !== NULL && count($scores) > 1 ? "*" : "" ?></td>
+				<td><? show_score_label($result, $scores); ?></td>
 				<td><time class="timeago" datetime="<?= date("c", strtotime($result["test_date"])) ?>"><?= date("c", strtotime($result["test_date"])) ?></time></td>
 			</tr>
 <?php


### PR DESCRIPTION
This commit adds a visual distinction to tests that are still running, and tests
that have failed. Where earlier, a '?' was shown for both, now, a red-labeled 'E'
is shown for tests that failed in error, while a spinner is shown for tests that
are still running.