### PR TITLE
Badge better links

### DIFF
--- a/badge.php
+++ b/badge.php
@@ -107,9 +107,11 @@ echo '<?xml version="1.0" standalone="no"?>';
 	<path fill="<?= svg_color($s2s_final_score) ?>" d="M150 0h4v18h-4z"/>
 	<rect rx="4" width="201" height="18" fill="url(#a)"/>
 	<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-		<a xlink:href="https://xmpp.net/result.php?domain=<?= urlencode($result_domain) ?>&amp;type=client">
+		<a xlink:href="https://xmpp.net/">
 			<text x="50.5" y="14" fill="#010101" fill-opacity=".3">xmpp.net score</text>
 			<text x="50.5" y="13">xmpp.net score</text>
+		</a>
+		<a xlink:href="https://xmpp.net/result.php?domain=<?= urlencode($result_domain) ?>&amp;type=client">
 			<text x="123.5" y="14" fill="#010101" fill-opacity=".3">c2s: <?= $c2s_final_score ? $c2s_final_score : "-"  ?></text>
 			<text x="123.5" y="13">c2s: <?= $c2s_final_score ? $c2s_final_score : "-"  ?></text>
 		</a>


### PR DESCRIPTION
Badge better links
It permits to have the xmpp.net at left part, client link on C2S part and server link on S2S part
- https://xmpp.net/
- https://xmpp.net/result.php?domain=domain.tld&type=client
- https://xmpp.net/result.php?domain=domain.tld&type=server